### PR TITLE
Added .ruby-* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@
 
 .env
 
+.ruby-*
+
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
Adds all .ruby-* files to gitignore.

So I can manage the project with RVM.

@th1988 please review